### PR TITLE
Fix Linux support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 exports.onWindow = (win) => {
-  win.maximize();
-  win.setFullScreen(true);
+  win.once('show', () => {
+    win.setFullScreen(true);
+  });
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
-exports.onWindow = (win) => {
-  win.once('show', () => {
-    setTimeout(() => {
-      win.setFullScreen(true);
-    }, 50);
-  });
-};
+'use strict';
+
+exports.decorateBrowserOptions = defaults => Object.assign({}, defaults, {
+  fullscreen: true
+});
+
+// Expose a no-op API method to workaround Hyper issue:
+// https://github.com/zeit/hyper/issues/2377
+exports.decorateConfig = config => config;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 exports.onWindow = (win) => {
   win.once('show', () => {
-    win.setFullScreen(true);
+    setTimeout(() => {
+      win.setFullScreen(true);
+    }, 50);
   });
 };


### PR DESCRIPTION
hyperfullscreen was not working reliably on my Ubuntu GNOME 16.04, this fixes the issue.

I haven't tested this on MacOS/Windows, but I believe it should work fine on those platforms as well.